### PR TITLE
DI-Mini, LED still ON after starting

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2778,7 +2778,7 @@ bool connectWifi()
   ESP_LOGD(TAG, "%s", WiFi.localIP().toString().c_str());
   ticker.detach(); // Stop blinking the LED because now we are connected:)
   // keep LED off (For Wemos D1-Mini)
-  digitalWrite(blueLedPin, LOW);
+  digitalWrite(blueLedPin, HIGH);
   // Auto reconnected
   WiFi.setAutoReconnect(true);
   WiFi.persistent(true);


### PR DESCRIPTION
Hello,
After starting, on a D1 Mini, led is still ON, and is annoying during night.
I think it's better to shutdown it. (or perhaps offer a select box into config page?)