### PR TITLE
Differentiate between cooling and heating when in auto mode.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2168,7 +2168,18 @@ String hpGetAction(heatpumpStatus hpStatus, heatpumpSettings hpSettings)
   else if (!hpStatus.operating)
     return "idle";
   else if (hpmode == "auto")
-    return "idle";
+  {
+    // If the "operating" flag is true and the heat pump is in "auto" mode,
+    // it's either heating or cooling, but its status packets don't explicitly
+    // indicate which of those two states it's in. We can infer the state by
+    // comparing the room temperature to the set point temperature.
+    if (hpStatus.roomTemperature > hpSettings.temperature) // above set point
+      return "cooling";
+    else if (hpStatus.roomTemperature < hpSettings.temperature) // below set point
+      return "heating";
+    else
+      return hpmode; // unknown
+  }
   else if (hpmode == "cool")
     return "cooling";
   else if (hpmode == "heat")


### PR DESCRIPTION
The current state update handling code incorrectly reports that the heat pump is always idling when it's in "auto" (heat/cool) mode, even when the `operating` flag is true.

This PR implements a short fix that correctly reports the heat pump's current action in auto mode, as tested on my SVZ-KP36NA unit. The heat pump's status packets don't explicitly indicate whether it's specifically heating or cooling, just that it's "operating" (i.e. doing one of the two), but we can infer which of the two actions must be occurring by checking whether the room temperature is above the set point (desired) temperature or below it.