### PR TITLE
Fix room temperature sensor unit (F/C) reporting.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2547,7 +2547,7 @@ void haConfigTemp(String tag, String icon) {
 
   haConfig["dev_cla"] = "temperature";
   haConfig["stat_t"] = ha_state_topic;
-  haConfig["unit_of_meas"] = "°C";
+  haConfig["unit_of_meas"] = useFahrenheit ? "°F" : "°C";
   haConfig["val_tpl"] = "{{value_json." + tag + "}}";
 
   JsonObject haConfigDevice = haConfig.createNestedObject("device");


### PR DESCRIPTION
`haConfigTemp()` unconditionally sets `unit_of_meas` for the `room_temperature` sensor to Celsius, even when configured to report temperatures in Fahrenheit — which results in reporting a temperature that is numerically in Fahrenheit but labeled as being in Celsius. If Home Assistant is also configured to default to Fahrenheit, it will do the C->F conversion a second time, displaying the wrong temperature (~160F room temperature!).

This is a one-line fix that conditionally reports the correct unit according to Mitsubishi2MQTT's `useFahrenheit` setting.