### PR TITLE
Fix memory leak in onMqttMessage() handler.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2380,12 +2380,15 @@ void mqttCallback(const char *topic, const uint8_t *payload, const unsigned int 
       }
       else
       {
-        return;
+        modeUpper = NULL;
       }
-      hpSendLocalState();
-      hp.setPowerSetting("ON");
-      hp.setModeSetting(modeUpper.c_str());
-      update = true;
+
+      if (modeUpper) {
+        hpSendLocalState();
+        hp.setPowerSetting("ON");
+        hp.setModeSetting(modeUpper.c_str());
+        update = true;
+      }
     }
   }
   else if (strcmp(topic, ha_temp_set_topic.c_str()) == 0)
@@ -2527,11 +2530,11 @@ void mqttCallback(const char *topic, const uint8_t *payload, const unsigned int 
     if (hp.getSettings() == hp.getWantedSettings()) // only update it settings change
     {
       ESP_LOGW(TAG, "Same Settings to HP, Igrore");
-      return;
+    } else {
+      ESP_LOGI(TAG, "Send Settings to HP");
+      requestHpUpdate = true;
+      requestHpUpdateTime = millis() + 10;
     }
-    ESP_LOGI(TAG, "Send Settings to HP");
-    requestHpUpdate = true;
-    requestHpUpdateTime = millis() + 10;
   }
   delete[] message;
 }


### PR DESCRIPTION
The `onMqttMessage()` handler copies the incoming MQTT message into a heap-allocated buffer, `message`, and calls `delete[] message` at the very end to deallocate this memory. However, there are early `return` statements that would trigger if either (a) setting the mode with an invalid mode string, or (b) taking any action that sets `update = true` but doesn't change a setting, like pushing a remote temperature reading.

In either case, `onMqttMessage()` will return without deallocating the message buffer, causing a memory leak. On an ESP-01, I found this to result in full memory exhaustion (as evidenced by an MQTT disconnect, persisting until the device was rebooted) every ~7.5 hours when submitting a remote temperature reading every 30 seconds.

This PR removes both `return` statements, replacing them with a logically equivalent control flow that ensures `delete[] message` is called in every case.