### PR TITLE
Optimize HA mqtt payload and HA entity initialization

### DIFF
--- a/main/config.h
+++ b/main/config.h
@@ -325,6 +325,15 @@ const char *const language_names[] = {
 };
 #endif
 
+const byte ENT_ROOM_TEMPERATURE = 0;
+const byte ENT_COMPR_FRQ = 1;
+const byte ENT_CONNECTION_STATE = 2;
+const byte ENT_UP_TIME = 3;
+const byte ENT_FREE_HEAP = 4;
+const byte ENT_RSSI = 5;
+const byte ENT_BSSI = 6;
+const byte ENT_RESTART_BTN = 10;
+
 static constexpr uint8_t NUM_LANGUAGES = sizeof(languages) / sizeof(const char *);
 
 // #define METRICS 1   // un comment to enable Prometheus exporter

--- a/main/config.h
+++ b/main/config.h
@@ -203,6 +203,8 @@ String wifi_static_dns_ip;
 String ntpServer = "pool.ntp.org";
 const long gmtOffset_sec = 3600;
 const int daylightOffset_sec = 3600;
+const time_t min_valid_date = 1000000;  // min time to consider device date valid
+time_t device_boot_time = 0;
 
 // Define global variables for MQTT
 String mqtt_fn;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2905,6 +2905,7 @@ void haConfigClimate()
   haConfig["temp_step"] = temp_step;
   haConfig["temperature_unit"] = useFahrenheit ? "F" : "C";
 
+  // fan control
   JsonArray haConfigFan_modes = haConfig.createNestedArray("fan_modes");
   haConfigFan_modes.add("auto");  //AUTO
   haConfigFan_modes.add("diffuse"); //QUIET
@@ -2917,6 +2918,7 @@ void haConfigClimate()
   haConfig["fan_mode_stat_t"] = ha_state_topic;
   haConfig["fan_mode_stat_tpl"] = F("{{ value_json.fan if (value_json is defined and value_json.fan is defined and value_json.fan|length) else 'auto' }}"); // Set default value for fix "Could not parse data for HA"
 
+  // vertical swing mode control
   JsonArray haConfigSwing_modes = haConfig.createNestedArray("swing_modes");
   haConfigSwing_modes.add("AUTO");
   haConfigSwing_modes.add("1");
@@ -2929,6 +2931,22 @@ void haConfigClimate()
   haConfig[F("swing_mode_cmd_t")] = ha_vane_set_topic;
   haConfig["swing_mode_stat_t"] = ha_state_topic;
   haConfig["swing_mode_stat_tpl"] = F("{{ value_json.vane if (value_json is defined and value_json.vane is defined and value_json.vane|length) else 'AUTO' }}"); // Set default value for fix "Could not parse data for HA"
+
+  // horizontal swing mode control
+  JsonArray haConfigSwing_H_modes = haConfig.createNestedArray("swing_h_modes");
+  haConfigSwing_H_modes.add("<<");
+  haConfigSwing_H_modes.add("<");
+  haConfigSwing_H_modes.add("|");
+  haConfigSwing_H_modes.add(">");
+  haConfigSwing_H_modes.add(">>");
+  haConfigSwing_H_modes.add("<>");
+  haConfigSwing_H_modes.add("SWING");
+
+  haConfig[F("swing_h_mode_cmd_t")] = ha_wide_vane_set_topic;
+  haConfig["swing_h_mode_stat_t"] = ha_state_topic;
+  haConfig["swing_h_mode_stat_tpl"] = F("{{ value_json.wideVane if (value_json is defined and value_json.wideVane is defined and value_json.wideVane|length) else 'SWING' }}"); // Set default value for fix "Could not parse data for HA"
+
+  // action control topic
   haConfig["action_topic"] = ha_state_topic;
   haConfig["action_template"] = F("{{ value_json.action if (value_json is defined and value_json.action is defined and value_json.action|length) else 'idle' }}"); // Set default value for fix "Could not parse data for HA"
 


### PR DESCRIPTION
Purpose of this PR is to optimize the creation of entities on HomeAssistant to solve some problems and add features:

- added support for horizontal swing mode for climate entity
- optimized the initialization code for HA entities to solve the problem where some sensors are not always initialized (memory / code optimization)
- revised logic for "up-time" sensor to not send continuous status updates to HA (managed as timestamp)
- revised MQTT payload structure and added device MAC address information 
- reorganized HA entities categories 

Tested on Wemos D1 device, compilation also successfully performed for ESP32 but I do not have such a device to verify its functioning