### PR TITLE
Fix web interface

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -999,7 +999,7 @@ void sendWrappedHTML(AsyncWebServerRequest *request, const String &content)
   toSend.replace(F("_UNIT_NAME_"), hostname);
   toSend.replace(F("_VERSION_"), getAppVersion());
   toSend.replace(F("_APP_NAME_"), appName);
-  request->send_P(200, "text/html", toSend.c_str());
+  request->send(200, "text/html", toSend);
   headerContent = "";
   footerContent = "";
 }


### PR DESCRIPTION
Following the `ESPAsyncWebServer` link library update , web interface show dirty characters as picture below:

![image](https://github.com/user-attachments/assets/d3386358-78e6-47a3-9488-0e78d98c9210)

Looks like using method `send_P` create problem because the buffer pointer is lost, using method `send` the issue is solved. 