### PR TITLE
Use device ID as Home Assistant root topic

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2709,12 +2709,9 @@ String haGetConfigTopic(String entity_type, String entity_tag = "")
   String ha_topic;
 
   ha_topic = (others_haa ? others_haa_topic : "homeassistant")  + "/" + entity_type + "/";
-  if (mqtt_fn.isEmpty()) {
-      mqtt_fn = getId();
-  }
-  ha_topic += mqtt_fn + "/";
+  ha_topic += "hvac_" + getId() + "/";
   if (!entity_tag.isEmpty()) {
-      ha_topic += entity_tag + "/";
+    ha_topic += entity_tag + "/";
   }
   ha_topic += "config";
   return ha_topic;


### PR DESCRIPTION
As best practice the root MQTT topic inside `HomeAssistant` tree should be an ID and not a friendly name to avoid any kind of conflict with other published devices.

Anyway I understand that this would be a breaking change from previous version and require to delete existing MQTT device in HA after firmware update.

Feel free to reject this PR if you are not confident with this change.