### PR TITLE
Change web send method for ESP32

### DIFF
--- a/main/config.h
+++ b/main/config.h
@@ -137,7 +137,7 @@ unsigned long lastRemoteTemp;
 // Local state
 StaticJsonDocument<JSON_OBJECT_SIZE(12)> rootInfo;
 String wifi_list = "";                            // cache wifi scan result
-const String localApIpUrl = "http://192.168.4.1"; // a string version of the local IP with http, used for redirecting clients to your webpage
+const String localApIpUrl = "http://8.8.8.8";     // a string version of the local IP with http, used for redirecting clients to your webpage
 String unique_id = "";                            // cache board unique id
 
 // Web OTA

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2756,7 +2756,8 @@ void haConfigureDevice(DynamicJsonDocument &haConfig)
   haConfigDevice[F("hw")] = String(ARDUINO_BOARD);  
   haConfigDevice[F("mdl")] = model;
   haConfigDevice[F("mf")] = manufacturer;
-  haConfigDevice[F("cu")] = "http://" + WiFi.localIP().toString();
+  if (!_webPanelDisable)
+    haConfigDevice[F("cu")] = "http://" + WiFi.localIP().toString();
 
   // availability topic
   haConfig[F("avty_t")] = ha_availability_topic;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -995,14 +995,23 @@ void sendWrappedHTML(AsyncWebServerRequest *request, const String &content)
   if (content.isEmpty())
     return;
 
-  String header = FPSTR(html_common_header);
-  header.replace(F("_APP_NAME_"), appName);
-  header.replace(F("_UNIT_NAME_"), hostname);
-
   String footer = FPSTR(html_common_footer);
   footer.replace(F("_APP_NAME_"), appName);
   footer.replace(F("_UNIT_NAME_"), hostname);
   footer.replace(F("_VERSION_"), getAppVersion() + F(" (") + String(ARDUINO_BOARD) + F(")"));
+
+  String response = FPSTR(html_common_header);
+  response.replace(F("_APP_NAME_"), appName);
+  response.replace(F("_UNIT_NAME_"), hostname);
+
+#ifdef ESP32
+
+  response += content;
+  response += footer;
+
+  request->send(200, "text/html", response);
+
+#else
 
   if (html_response != NULL)
   {
@@ -1010,16 +1019,17 @@ void sendWrappedHTML(AsyncWebServerRequest *request, const String &content)
     html_response = NULL;
   }
 
-  html_resp_length = header.length() + content.length() + footer.length();
+  html_resp_length = response.length() + content.length() + footer.length();
   html_response = new char[html_resp_length + 1];
-  memcpy(html_response, header.c_str(), header.length());
-  u_int16_t index = header.length();
+  memcpy(html_response, response.c_str(), response.length());
+  u_int16_t index = response.length();
   memcpy(html_response + index, content.c_str(), content.length());
   index += content.length();
   memcpy(html_response + index, footer.c_str(), footer.length());
   html_response[html_resp_length] = '\0';
 
   request->send_P(200, "text/html", html_response);
+#endif
 }
 
 void handleNotFound(AsyncWebServerRequest *request)


### PR DESCRIPTION
When using ESP32 is better to use `send` method instead of `send_P`, because the last is deprecated for ESP32.

Also added other 2 little fix:

1) updated default address of captive portal to `8.8.8.8`
2) Hide HA device link from device page when web-panel is disabled
