### PR TITLE
Turn off blue led on ESP32 and change default main topic

### DIFF
--- a/main/config.h
+++ b/main/config.h
@@ -225,6 +225,7 @@ String mqtt_root_ca_cert;
 String mqtt_client_id;
 const PROGMEM char *mqtt_payload_available = "online";
 const PROGMEM char *mqtt_payload_unavailable = "offline";
+const PROGMEM char *default_mqtt_topic = "mitsubishi2mqtt";
 
 // Define global variables for Others settings
 bool others_haa;


### PR DESCRIPTION
2 very little changes:

1) Turn-off blue led when connected for ESP32 (as for WemosD1)
2) Set main MQTT default topic to `mitsubishi2mqtt`  (used only at first startup when still not configured)
