### PR TITLE
Use variable for blue led off status

### DIFF
--- a/main/config.h
+++ b/main/config.h
@@ -169,6 +169,8 @@ const PROGMEM char *console_file = "/console.log";
 const PROGMEM char *others_conf = "/others.json";
 // pinouts
 const PROGMEM uint8_t blueLedPin = 2; // The ESP32 has an internal blue LED at D2 (GPIO 02)
+// keep LED off (check board schematic)
+uint8_t blueLedDisabled = LOW;
 #else
 const PROGMEM char *wifi_conf = "wifi.json";
 const PROGMEM char *mqtt_conf = "mqtt.json";
@@ -177,6 +179,8 @@ const PROGMEM char *console_file = "console.log";
 const PROGMEM char *others_conf = "others.json";
 // pinouts
 const PROGMEM uint8_t blueLedPin = LED_BUILTIN; // Onboard LED = digital pin 2 "D4" (blue LED on WEMOS D1-Mini)
+// keep LED off (For Wemos D1-Mini), Other board check the schematic
+uint8_t blueLedDisabled = HIGH;
 #endif
 const PROGMEM uint8_t redLedPin = 0;
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3143,13 +3143,8 @@ bool connectWifi()
     }
     ESP_LOGD(TAG, "%s", WiFi.localIP().toString().c_str());
     ticker.detach();  // Stop blinking the LED because now we are connected:)
-#ifdef ESP32
     // keep LED off
-    digitalWrite(blueLedPin, LOW);
-#else
-    // keep LED off (For Wemos D1-Mini), Other board check the schematic
-    digitalWrite(blueLedPin, HIGH);
-#endif
+    digitalWrite(blueLedPin, blueLedDisabled);
     // Auto reconnected
     WiFi.setAutoReconnect(true);
     WiFi.persistent(true);
@@ -3410,8 +3405,8 @@ void WiFiEvent(WiFiEvent_t event)
     {
       mqtt_reconnect_timeout = millis() + MQTT_RECONNECT_INTERVAL_MS; // only retry next 5 seconds to prevent crash
       ticker.detach();                                                // Stop blinking the LED because now we are connected:)
-      // keep LED off (check the schematic)
-      digitalWrite(blueLedPin, LOW);
+      // keep LED off
+      digitalWrite(blueLedPin, blueLedDisabled);
       xTimerStart(mqttReconnectTimer, 0); // start timer to connect to MQTT
       // init and get the time
       configTime(gmtOffset_sec, daylightOffset_sec, ntpServer.c_str());
@@ -3446,8 +3441,8 @@ void onWifiConnect(const WiFiEventStationModeGotIP &event)
   {
     mqtt_reconnect_timeout = millis() + MQTT_RECONNECT_INTERVAL_MS; // only retry next 5 seconds to prevent crash
     ticker.detach();                                                // Stop blinking the LED because now we are connected:)
-    // keep LED off (For Wemos D1-Mini), Other board check the schematic
-    digitalWrite(blueLedPin, HIGH);
+    // keep LED off
+    digitalWrite(blueLedPin, blueLedDisabled);
     mqttConnect();
     // init and get the time
     configTime(gmtOffset_sec, daylightOffset_sec, ntpServer);


### PR DESCRIPTION
Follow up to PR #61 .

Just use a variable for the value used to turn blue led off. This is just starting point to implement a new option to properly configure the led control depending on the board used.